### PR TITLE
Node 12.14.1

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -205,3 +205,7 @@ Starting from version 3.5.0, the `PlannerProvider` may optionally also implement
         return new PlannerExecutable(`java -jar ${configuration.path}`, plannerOptions, configuration.syntax, workingDirectory);
     }
 ```
+
+## Compiling and contributing
+
+Install node.js 12.14.1.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl-workspace",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl-workspace",
-  "version": "4.0.0",
+  "version": "4.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -331,21 +331,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "13.9.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/node/-/node-13.9.2.tgz",
-      "integrity": "sha1-rOGIDANZTMPoAgbZaEcVfY5/o0k=",
+      "version": "12.19.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/node/-/node-12.19.4.tgz",
+      "integrity": "sha1-zfu2LibHQ17ZqrnJQTk8w1mOm0Y=",
       "dev": true
     },
     "@types/nunjucks": {
       "version": "3.1.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/nunjucks/-/nunjucks-3.1.3.tgz",
       "integrity": "sha1-Vfor9v00ZBVFpmhiFzJP3mbTEWQ=",
-      "dev": true
-    },
-    "@types/tmp": {
-      "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha1-Gc9zp7z2QZZUhRGXJjl6CW8ASb0=",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -529,7 +523,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "binary-extensions": {
       "version": "2.0.0",
@@ -540,6 +535,7 @@
       "version": "1.1.11",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -702,7 +698,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -1164,7 +1161,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "2.1.2",
@@ -1206,6 +1204,7 @@
       "version": "7.1.6",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/glob/-/glob-7.1.6.tgz",
       "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -1328,6 +1327,7 @@
       "version": "1.0.6",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1336,7 +1336,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+      "dev": true
     },
     "inquirer": {
       "version": "7.1.0",
@@ -1810,6 +1811,7 @@
       "version": "3.0.4",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -2223,6 +2225,7 @@
       "version": "1.4.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -2324,7 +2327,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
@@ -2503,6 +2507,7 @@
       "version": "2.6.3",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -2776,22 +2781,6 @@
         }
       }
     },
-    "tmp": {
-      "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tmp/-/tmp-0.1.0.tgz",
-      "integrity": "sha1-7kNKTiJUMILilLpiAdzG6v76KHc=",
-      "requires": {
-        "rimraf": "^2.6.3"
-      }
-    },
-    "tmp-promise": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tmp-promise/-/tmp-promise-2.0.2.tgz",
-      "integrity": "sha1-7mBe2xDxAJVL5d2Lnb4b/VYZQgI=",
-      "requires": {
-        "tmp": "0.1.0"
-      }
-    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -2960,7 +2949,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,33 +5,33 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.8.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/code-frame/-/code-frame-7.8.3.tgz",
-      "integrity": "sha1-M+JZA9dIEYFTThLsCiXxa2/PQZ4=",
+      "version": "7.10.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha1-Fo2ho26Q2miujUnA8bSMfGJJITo=",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.8.3"
+        "@babel/highlight": "^7.10.4"
       }
     },
     "@babel/core": {
-      "version": "7.9.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/core/-/core-7.9.0.tgz",
-      "integrity": "sha1-rJd7U4t34TL/cG87ik260JwDxW4=",
+      "version": "7.12.9",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/core/-/core-7.12.9.tgz",
+      "integrity": "sha1-/UUMTsEM27mA4pKLeqeihIRZP8g=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.0",
-        "@babel/helper-module-transforms": "^7.9.0",
-        "@babel/helpers": "^7.9.0",
-        "@babel/parser": "^7.9.0",
-        "@babel/template": "^7.8.6",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.5",
+        "@babel/helper-module-transforms": "^7.12.1",
+        "@babel/helpers": "^7.12.5",
+        "@babel/parser": "^7.12.7",
+        "@babel/template": "^7.12.7",
+        "@babel/traverse": "^7.12.9",
+        "@babel/types": "^7.12.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
         "json5": "^2.1.2",
-        "lodash": "^4.17.13",
+        "lodash": "^4.17.19",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
@@ -46,170 +46,170 @@
       }
     },
     "@babel/generator": {
-      "version": "7.9.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/generator/-/generator-7.9.0.tgz",
-      "integrity": "sha1-D2et6k7Dna1uYzRfcO7DMBTXjIk=",
+      "version": "7.12.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/generator/-/generator-7.12.5.tgz",
+      "integrity": "sha1-osUN5ci21wirlb5eYFOTbBiEpN4=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.9.0",
+        "@babel/types": "^7.12.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.8.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz",
-      "integrity": "sha1-7utmWgGx8RBo6fuGrVahyxqCTMo=",
+      "version": "7.10.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha1-0tOyDFmtjEcRL6fSqUvAnV74Lxo=",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.8.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-      "integrity": "sha1-uJS5R70AQ4HOY+odufCFR+kgq9U=",
+      "version": "7.10.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha1-mMHL6g4jMvM/mkZhuM4VBbLBm6I=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.8.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-      "integrity": "sha1-ZZtxBJjqbB2ZB+DHPyBu7n2twkw=",
+      "version": "7.12.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+      "integrity": "sha1-qne9A5bsgRTl4weH76eFmdh0qFU=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.8.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
-      "integrity": "sha1-f+OVibOcAWMxtrjD9EHo8LFBlJg=",
+      "version": "7.12.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+      "integrity": "sha1-G/wCKfeUmI927QpNTpCGCFC1Tfs=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.9.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
-      "integrity": "sha1-Q7NN/hWWGRhwfSRzJ0MTiOn+luU=",
+      "version": "7.12.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+      "integrity": "sha1-eVT+xx9bMsSOSzA7Q3w0RT/XJHw=",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.8.3",
-        "@babel/helper-replace-supers": "^7.8.6",
-        "@babel/helper-simple-access": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/template": "^7.8.6",
-        "@babel/types": "^7.9.0",
-        "lodash": "^4.17.13"
+        "@babel/helper-module-imports": "^7.12.1",
+        "@babel/helper-replace-supers": "^7.12.1",
+        "@babel/helper-simple-access": "^7.12.1",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.1",
+        "@babel/types": "^7.12.1",
+        "lodash": "^4.17.19"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.8.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-      "integrity": "sha1-ftBxgT0Jx1KY708giVYAa2ER7Lk=",
+      "version": "7.12.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.7.tgz",
+      "integrity": "sha1-f5SuXghyGklGc0aqBP0i91ADO5w=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.8.6",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-      "integrity": "sha1-Wtp0T9WtcyA78dZ0WaJ9y6Z+/8g=",
+      "version": "7.12.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
+      "integrity": "sha1-8AmhdUO7u84WsGIGrnO2PT/KaNk=",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.8.3",
-        "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/helper-member-expression-to-functions": "^7.12.1",
+        "@babel/helper-optimise-call-expression": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.8.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
-      "integrity": "sha1-f4EJkotNq0ZUB2mGr1dSMd62Oa4=",
+      "version": "7.12.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+      "integrity": "sha1-MkJ+WqYVR9OOsebq9f0UJv2tkTY=",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.12.1"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.8.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-      "integrity": "sha1-ManzAHD5E2inGCzwX4MXgQZfx6k=",
+      "version": "7.11.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz",
+      "integrity": "sha1-+KSRJErPamdhWKxCBykRuoOtCZ8=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.11.0"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.9.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
-      "integrity": "sha1-rVNWKn/Cmzuakbv30QOX/RRjRu0=",
+      "version": "7.10.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha1-p4x6clHgH2FlEtMbEK3PUq2l4NI=",
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.9.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helpers/-/helpers-7.9.0.tgz",
-      "integrity": "sha1-qywbxIIa92bKtR1IaKUDiHTqWhI=",
+      "version": "7.12.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/helpers/-/helpers-7.12.5.tgz",
+      "integrity": "sha1-Ghukp2jZtYMQ7aUWxEmRP+ZHEW4=",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0"
+        "@babel/template": "^7.10.4",
+        "@babel/traverse": "^7.12.5",
+        "@babel/types": "^7.12.5"
       }
     },
     "@babel/highlight": {
-      "version": "7.9.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/highlight/-/highlight-7.9.0.tgz",
-      "integrity": "sha1-TptFzLgreWBycbKXmtgse2gWMHk=",
+      "version": "7.10.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha1-fRvf1ldTU4+r5sOFls23bZrGAUM=",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.9.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/parser/-/parser-7.9.0.tgz",
-      "integrity": "sha1-+CGzIxPwfuVwl20/Yjjo0tZuCo4=",
+      "version": "7.12.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/parser/-/parser-7.12.7.tgz",
+      "integrity": "sha1-/uezn+gJ0Oc+WyXuyvV4DvPXMFY=",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.8.6",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/template/-/template-7.8.6.tgz",
-      "integrity": "sha1-hrIq8V+CjfsIZHT5ZNzD45xDzis=",
+      "version": "7.12.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/template/-/template-7.12.7.tgz",
+      "integrity": "sha1-yBcjNpYBjjn7tsSR0vtoTgXtQ7w=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.9.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/traverse/-/traverse-7.9.0.tgz",
-      "integrity": "sha1-04gsKDDlE/T+TOyf526hzHh0eJI=",
+      "version": "7.12.9",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/traverse/-/traverse-7.12.9.tgz",
+      "integrity": "sha1-+tJsly6rvBE1DgtpWXjebMjoWW8=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.0",
-        "@babel/helper-function-name": "^7.8.3",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.0",
-        "@babel/types": "^7.9.0",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.12.5",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.11.0",
+        "@babel/parser": "^7.12.7",
+        "@babel/types": "^7.12.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.13"
+        "lodash": "^4.17.19"
       },
       "dependencies": {
         "globals": {
@@ -221,24 +221,25 @@
       }
     },
     "@babel/types": {
-      "version": "7.9.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/types/-/types-7.9.0.tgz",
-      "integrity": "sha1-ALBkw9+DrTKy2/X/BzErFcfx77U=",
+      "version": "7.12.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@babel/types/-/types-7.12.7.tgz",
+      "integrity": "sha1-YDn/HiQmQKKUUsmuVyFi7JqPXRM=",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.0",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@istanbuljs/load-nyc-config": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
-      "integrity": "sha1-EGAt5VcLrqgvivv6JjCyTnqM/ls=",
+      "version": "1.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha1-/T2x1Z7PfPEh6AZQu4ZxL5tV7O0=",
       "dev": true,
       "requires": {
         "camelcase": "^5.3.1",
         "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
         "js-yaml": "^3.13.1",
         "resolve-from": "^5.0.0"
       },
@@ -306,12 +307,6 @@
         "@types/chai": "*"
       }
     },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-HBJhu+qhCoBVu8XYq4S3sq/IRqA=",
-      "dev": true
-    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -319,9 +314,9 @@
       "dev": true
     },
     "@types/json-schema": {
-      "version": "7.0.4",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/json-schema/-/json-schema-7.0.4.tgz",
-      "integrity": "sha1-OP1z3f2bVaux4bLtV4y1W9e30zk=",
+      "version": "7.0.6",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/json-schema/-/json-schema-7.0.6.tgz",
+      "integrity": "sha1-9MfsQ+gbMZqYFRFQMXCfJph4kfA=",
       "dev": true
     },
     "@types/mocha": {
@@ -331,9 +326,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.19.4",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/node/-/node-12.19.4.tgz",
-      "integrity": "sha1-zfu2LibHQ17ZqrnJQTk8w1mOm0Y=",
+      "version": "12.19.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@types/node/-/node-12.19.7.tgz",
+      "integrity": "sha1-z4tqwIjdkYKsmh12X3h6jRJJDAQ=",
       "dev": true
     },
     "@types/nunjucks": {
@@ -343,45 +338,45 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.24.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz",
-      "integrity": "sha1-qGz2GMllpGLN3zYB9ZRUSxNNbWg=",
+      "version": "2.34.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
+      "integrity": "sha1-b4zopGx96kpvHRcdK7j7rm2sK+k=",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.24.0",
-        "eslint-utils": "^1.4.3",
+        "@typescript-eslint/experimental-utils": "2.34.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.24.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz",
-      "integrity": "sha1-pcsu2J/t+LWWONyDSE6wyMNeEUM=",
+      "version": "2.34.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
+      "integrity": "sha1-01JLZEzbQO687KZ/jPPkzJyPmA8=",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.24.0",
-        "eslint-scope": "^5.0.0"
+        "@typescript-eslint/typescript-estree": "2.34.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.24.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/parser/-/parser-2.24.0.tgz",
-      "integrity": "sha1-LPDq5ubdRNFiSGrZScEmuIfxHrg=",
+      "version": "2.34.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/parser/-/parser-2.34.0.tgz",
+      "integrity": "sha1-UCUmMMoxloVCDpo5ygX+GFola8g=",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.24.0",
-        "@typescript-eslint/typescript-estree": "2.24.0",
+        "@typescript-eslint/experimental-utils": "2.34.0",
+        "@typescript-eslint/typescript-estree": "2.34.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.24.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz",
-      "integrity": "sha1-OLvIu0eXkNLzJHl/+82zRtiXxio=",
+      "version": "2.34.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+      "integrity": "sha1-FK62NTs57wcyzH8bgoUpSTfPN9U=",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -389,7 +384,7 @@
         "glob": "^7.1.6",
         "is-glob": "^4.0.1",
         "lodash": "^4.17.15",
-        "semver": "^6.3.0",
+        "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       }
     },
@@ -399,21 +394,21 @@
       "integrity": "sha1-dba2qnJZi0l6El56J3DxT0yKH6c="
     },
     "acorn": {
-      "version": "7.1.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/acorn/-/acorn-7.1.1.tgz",
-      "integrity": "sha1-41Zo3gtALzWd5RXFSCoaufiaab8=",
+      "version": "7.4.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha1-/q7SVZc9LndVW4PbwIhRpsY1IPo=",
       "dev": true
     },
     "acorn-jsx": {
-      "version": "5.2.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
-      "integrity": "sha1-TGYGkXPW/daO2FI5/CViJhgrLr4=",
+      "version": "5.3.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha1-/IZh4Rt6wVOcR9v+oucrOvNNJns=",
       "dev": true
     },
     "aggregate-error": {
-      "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha1-2y/nJG5Tb0DZtUQqOeEX191qJOA=",
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha1-kmcP9Q9TWb23o+DUDQ7DDFc3aHo=",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -421,9 +416,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ajv/-/ajv-6.12.0.tgz",
-      "integrity": "sha1-BtYLlth7hFSlrauobnhU2mKdtLc=",
+      "version": "6.12.6",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha1-uvWmLoArB9l3A0WG+MO69a3ybfQ=",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
@@ -527,9 +522,9 @@
       "dev": true
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w="
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha1-MPpAyef+B9vIlWeM0ocCTeokHdk="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -565,6 +560,16 @@
         "make-dir": "^3.0.0",
         "package-hash": "^4.0.0",
         "write-file-atomic": "^3.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha1-JBJwVLs/m9y0sfuCQYGGBy93uM4=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
       }
     },
     "callsites": {
@@ -623,18 +628,19 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.3.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha1-EsBxRmjFWAD2WeJi1JYql/r1VKY=",
+      "version": "3.4.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha1-wd84IxRI5FykrFiObHlXO6alfVs=",
+      "optional": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.2.0"
+        "readdirp": "~3.5.0"
       }
     },
     "clean-stack": {
@@ -653,9 +659,9 @@
       }
     },
     "cli-width": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "version": "3.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cli-width/-/cli-width-3.0.0.tgz",
+      "integrity": "sha1-ovSEN6LKqaIkNueUvwceyeYc7fY=",
       "dev": true
     },
     "cliui": {
@@ -685,9 +691,9 @@
       "dev": true
     },
     "commander": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/commander/-/commander-3.0.2.tgz",
-      "integrity": "sha1-aDfD+2d62ZM9HPukLdFNURfWs54="
+      "version": "5.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha1-Rqu9FlL44Fm92u+Zu9yyrZzxea4="
     },
     "commondir": {
       "version": "1.0.1",
@@ -752,12 +758,12 @@
       }
     },
     "debug": {
-      "version": "4.1.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/debug/-/debug-4.1.1.tgz",
-      "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
+      "version": "4.3.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/debug/-/debug-4.3.1.tgz",
+      "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.2"
       }
     },
     "decamelize": {
@@ -821,22 +827,37 @@
       "dev": true
     },
     "es-abstract": {
-      "version": "1.17.4",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/es-abstract/-/es-abstract-1.17.4.tgz",
-      "integrity": "sha1-467fGXBrIOfCWUw1/A1XYFp54YQ=",
+      "version": "1.18.0-next.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha1-bjoKS9pxflAjqzuOkL7DYQjSLGg=",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
-        "object-inspect": "^1.7.0",
+        "is-callable": "^1.2.2",
+        "is-negative-zero": "^2.0.0",
+        "is-regex": "^1.1.1",
+        "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "object.assign": "^4.1.1",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      },
+      "dependencies": {
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "es-to-primitive": {
@@ -907,37 +928,52 @@
         "v8-compile-cache": "^2.0.3"
       },
       "dependencies": {
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
         "regexpp": {
           "version": "2.0.1",
           "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/regexpp/-/regexpp-2.0.1.tgz",
           "integrity": "sha1-jRnTHPYySCtYkEn4KB+T28uk0H8=",
           "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
         }
       }
     },
     "eslint-scope": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/eslint-scope/-/eslint-scope-5.0.0.tgz",
-      "integrity": "sha1-6HyIh8c+jR7ITxylkWRcNYv8j7k=",
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha1-54blmmbLkrP2wfsNUIqrF0hI9Iw=",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha1-dP7HxU0Hdrb2fgJRBAtYBlZOmB8=",
+      "version": "2.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha1-0t5eA0JOcH3BDHQGjd7a5wh0Gyc=",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
+      "version": "1.3.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+      "integrity": "sha1-MOvR73wv3/AcOk8VEESvJfqwUj4=",
       "dev": true
     },
     "espree": {
@@ -958,21 +994,37 @@
       "dev": true
     },
     "esquery": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/esquery/-/esquery-1.1.0.tgz",
-      "integrity": "sha1-xcC2bzg+dlZAT4azEzTXJSTt20g=",
+      "version": "1.3.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha1-t4tYKKqOIU4p+3TE1bdS4cAz2lc=",
       "dev": true,
       "requires": {
-        "estraverse": "^4.0.0"
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+          "dev": true
+        }
       }
     },
     "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
+      "version": "4.3.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha1-eteWTWeauyi+5yzsY3WLHF0smSE=",
       "dev": true,
       "requires": {
-        "estraverse": "^4.1.0"
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha1-MH30JUfmzHMk088DwVXVzbjFOIA=",
+          "dev": true
+        }
       }
     },
     "estraverse": {
@@ -996,23 +1048,12 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
-      },
-      "dependencies": {
-        "tmp": {
-          "version": "0.0.33",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
-          "dev": true,
-          "requires": {
-            "os-tmpdir": "~1.0.2"
-          }
-        }
       }
     },
     "fast-deep-equal": {
-      "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha1-VFFFB3xQFJHjOxXsQIwpQ3bpSuQ=",
+      "version": "3.1.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha1-On1WtVnWy8PrUSMlJE5hmmXGxSU=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -1074,9 +1115,9 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
+      "version": "4.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/flat/-/flat-4.1.1.tgz",
+      "integrity": "sha1-o5IFnMOCiB/5hkL12k3eCpWfMJs=",
       "dev": true,
       "requires": {
         "is-buffer": "~2.0.3"
@@ -1094,9 +1135,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/flatted/-/flatted-2.0.1.tgz",
-      "integrity": "sha1-aeV8qo8OrLwoHS4stFjUb9tEngg=",
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
       "dev": true
     },
     "foreground-child": {
@@ -1110,9 +1151,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha1-CrVihuD3wk4VPQTMKqAn5DqaXRQ=",
+          "version": "7.0.3",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -1153,9 +1194,9 @@
       }
     },
     "fromentries": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fromentries/-/fromentries-1.2.0.tgz",
-      "integrity": "sha1-5qoG8kDWJn+RPOpCIHXviLY+eJc=",
+      "version": "1.3.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha1-5LymgIgWv4+TtSdQ8RJ/Wm/Ybjo=",
       "dev": true
     },
     "fs.realpath": {
@@ -1165,9 +1206,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha1-TAofs0vGjlQ7S4Kp7Dkr+9qECAU=",
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha1-+3OHA66NL5/pAMM4Nt3r7ouX8j4=",
       "optional": true
     },
     "function-bind": {
@@ -1183,9 +1224,9 @@
       "dev": true
     },
     "gensync": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha1-WPQ2H/mH5f9uHnohCCeqNx6qwmk=",
+      "version": "1.0.0-beta.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha1-MqbudsPX9S1GsrGuXZP+qFgKJeA=",
       "dev": true
     },
     "get-caller-file": {
@@ -1198,6 +1239,23 @@
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.0.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+      "integrity": "sha1-lKl2j8vdBZWhySc6rPTInQdWMb4=",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
+    },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha1-jeLYA8/0TfO8bEVuZmizbDkm4Ro=",
       "dev": true
     },
     "glob": {
@@ -1215,9 +1273,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha1-X0wdHnSNMM1zrSlEs1d6gbCB6MI=",
+      "version": "5.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha1-tsHvQXxOVmPqSY8cRa+saRa7wik=",
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -1232,9 +1290,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha1-ShL/G2A3bvCYYsIJPt2Qgyi+hCM=",
+      "version": "4.2.4",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha1-Ila94U02MpWMRl68ltxGfKB6Kfs=",
       "dev": true
     },
     "growl": {
@@ -1265,9 +1323,9 @@
       "dev": true
     },
     "hasha": {
-      "version": "5.2.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/hasha/-/hasha-5.2.0.tgz",
-      "integrity": "sha1-MwlNH2nECkpqx75T1f4/+Vomngw=",
+      "version": "5.2.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/hasha/-/hasha-5.2.2.tgz",
+      "integrity": "sha1-pIR3mJs7MnrqPAT1MJbYFtl1IqE=",
       "dev": true,
       "requires": {
         "is-stream": "^2.0.0",
@@ -1281,9 +1339,9 @@
       "dev": true
     },
     "html-escaper": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/html-escaper/-/html-escaper-2.0.0.tgz",
-      "integrity": "sha1-ceh/kx3j/gnlZmGrmimq3scHtJE=",
+      "version": "2.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha1-39YAJ9o2o238viNiYsAKWCJoFFM=",
       "dev": true
     },
     "iconv-lite": {
@@ -1302,9 +1360,9 @@
       "dev": true
     },
     "import-fresh": {
-      "version": "3.2.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/import-fresh/-/import-fresh-3.2.1.tgz",
-      "integrity": "sha1-Yz/2GFBueTr1rJG/SLcmd+FcvmY=",
+      "version": "3.2.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/import-fresh/-/import-fresh-3.2.2.tgz",
+      "integrity": "sha1-/BKcFgxdaCNVB/QzGmuq0Ya9vD4=",
       "dev": true,
       "requires": {
         "parent-module": "^1.0.0",
@@ -1340,21 +1398,21 @@
       "dev": true
     },
     "inquirer": {
-      "version": "7.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inquirer/-/inquirer-7.1.0.tgz",
-      "integrity": "sha1-EpigGFmIPhfHJkuChwrhA0+S3Sk=",
+      "version": "7.3.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/inquirer/-/inquirer-7.3.3.tgz",
+      "integrity": "sha1-BNF2sq8Er8FXqD/XwQDpjuCq0AM=",
       "dev": true,
       "requires": {
         "ansi-escapes": "^4.2.1",
-        "chalk": "^3.0.0",
+        "chalk": "^4.1.0",
         "cli-cursor": "^3.1.0",
-        "cli-width": "^2.0.0",
+        "cli-width": "^3.0.0",
         "external-editor": "^3.0.3",
         "figures": "^3.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.19",
         "mute-stream": "0.0.8",
         "run-async": "^2.4.0",
-        "rxjs": "^6.5.3",
+        "rxjs": "^6.6.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
@@ -1367,19 +1425,18 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "version": "4.3.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+          "version": "4.1.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha1-ThSHCmGNni7dl92DRf2dncMVZGo=",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -1440,9 +1497,9 @@
           }
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "version": "7.2.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -1459,16 +1516,25 @@
       }
     },
     "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha1-PlcvI8hBGlz9lVfISeNmXgspBiM=",
+      "version": "2.0.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha1-68JS5ADSL/jXf6CYiIIaJKZYwZE=",
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs=",
+      "version": "1.2.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-callable/-/is-callable-1.2.2.tgz",
+      "integrity": "sha1-x8ZxXNItTdtI0+GZcCI6zquwgNk=",
       "dev": true
+    },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha1-lwN+89UiJNhRY/VZeytj2a/tmBo=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
     },
     "is-date-object": {
       "version": "1.0.2",
@@ -1495,24 +1561,24 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss="
     },
-    "is-promise": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
-      "dev": true
-    },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
+      "version": "1.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha1-xvmKrMVG9s7FRooHt7FTq1ZKV7k=",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-stream": {
@@ -1570,18 +1636,23 @@
       }
     },
     "istanbul-lib-instrument": {
-      "version": "4.0.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.1.tgz",
-      "integrity": "sha1-YfE6wsls/vsHb+cTEVbMBZB4dOY=",
+      "version": "4.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha1-hzxv/4l0UBGCIndGlqPyiQLXfB0=",
       "dev": true,
       "requires": {
         "@babel/core": "^7.7.5",
-        "@babel/parser": "^7.7.5",
-        "@babel/template": "^7.7.4",
-        "@babel/traverse": "^7.7.4",
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-processinfo": {
@@ -1600,9 +1671,9 @@
       },
       "dependencies": {
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha1-CrVihuD3wk4VPQTMKqAn5DqaXRQ=",
+          "version": "7.0.3",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha1-9zqFudXUHQRVUcF34ogtSshXKKY=",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -1669,9 +1740,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha1-aOMlkd9z4lrRxLSRCKLsUHliv9E=",
+          "version": "7.2.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha1-G33NyzK4E4gBs+R4umpRyqiWSNo=",
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
@@ -1699,9 +1770,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/istanbul-reports/-/istanbul-reports-3.0.0.tgz",
-      "integrity": "sha1-1NFtA125lYG2GU4Rm782yWPF63A=",
+      "version": "3.0.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha1-1ZMhDlAAaDdQywn8BkTktuJ/1Ts=",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -1715,9 +1786,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+      "version": "3.14.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1743,9 +1814,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/json5/-/json5-2.1.2.tgz",
-      "integrity": "sha1-Q+8fCvmDXdYkdRprf6SIdPstYI4=",
+      "version": "2.1.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha1-ybD3+pIzv+WAf+ZvzzpWF+1ZfUM=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
@@ -1772,9 +1843,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.20",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha1-tEqbYpe8tpjxxRo1RaKzs2jVnFI=",
       "dev": true
     },
     "lodash.flattendeep": {
@@ -1793,12 +1864,20 @@
       }
     },
     "make-dir": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/make-dir/-/make-dir-3.0.2.tgz",
-      "integrity": "sha1-BKGsvyIiHh1u9DVZ9D4FqQ27Q5I=",
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha1-QV6WcEazp/HRhSd9hKpYIDcmoT8=",
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+          "dev": true
+        }
       }
     },
     "mimic-fn": {
@@ -1823,18 +1902,18 @@
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
+      "version": "0.5.5",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
     },
     "mocha": {
-      "version": "7.1.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/mocha/-/mocha-7.1.1.tgz",
-      "integrity": "sha1-ifuzDQlCmEWxu4k6gwv1dxBJpEE=",
+      "version": "7.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha1-AcwiewDYdase7QOnUQZonP7VpgQ=",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -1850,7 +1929,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.3",
+        "mkdirp": "0.5.5",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
@@ -1863,6 +1942,22 @@
         "yargs-unparser": "1.6.0"
       },
       "dependencies": {
+        "chokidar": {
+          "version": "3.3.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/chokidar/-/chokidar-3.3.0.tgz",
+          "integrity": "sha1-EsBxRmjFWAD2WeJi1JYql/r1VKY=",
+          "dev": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.1",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.2.0"
+          }
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/debug/-/debug-3.2.6.tgz",
@@ -1886,11 +1981,30 @@
             "path-is-absolute": "^1.0.0"
           }
         },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
+        },
+        "readdirp": {
+          "version": "3.2.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readdirp/-/readdirp-3.2.0.tgz",
+          "integrity": "sha1-wwwzNSsSyW37S4lUIaSf1alZODk=",
+          "dev": true,
+          "requires": {
+            "picomatch": "^2.0.4"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -1976,20 +2090,20 @@
       "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU="
     },
     "nunjucks": {
-      "version": "3.2.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/nunjucks/-/nunjucks-3.2.1.tgz",
-      "integrity": "sha1-8ilTkoHpLGrSXYxXjJvbQWVcr4M=",
+      "version": "3.2.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/nunjucks/-/nunjucks-3.2.2.tgz",
+      "integrity": "sha1-RfkV/vD4n7qzjEidyFAl9khZ9GY=",
       "requires": {
         "a-sync-waterfall": "^1.0.0",
         "asap": "^2.0.3",
         "chokidar": "^3.3.0",
-        "commander": "^3.0.2"
+        "commander": "^5.1.0"
       }
     },
     "nyc": {
-      "version": "15.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/nyc/-/nyc-15.0.0.tgz",
-      "integrity": "sha1-6zLbLA8pJCwkFP5GNX8jASHPwWI=",
+      "version": "15.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/nyc/-/nyc-15.1.0.tgz",
+      "integrity": "sha1-EzXa4S3ch7biSdWhmUykva6nXwI=",
       "dev": true,
       "requires": {
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -2000,6 +2114,7 @@
         "find-cache-dir": "^3.2.0",
         "find-up": "^4.1.0",
         "foreground-child": "^2.0.0",
+        "get-package-type": "^0.1.0",
         "glob": "^7.1.6",
         "istanbul-lib-coverage": "^3.0.0",
         "istanbul-lib-hook": "^3.0.0",
@@ -2007,10 +2122,9 @@
         "istanbul-lib-processinfo": "^2.0.2",
         "istanbul-lib-report": "^3.0.0",
         "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.0.0",
-        "js-yaml": "^3.13.1",
+        "istanbul-reports": "^3.0.2",
         "make-dir": "^3.0.0",
-        "node-preload": "^0.2.0",
+        "node-preload": "^0.2.1",
         "p-map": "^3.0.0",
         "process-on-spawn": "^1.0.0",
         "resolve-from": "^5.0.0",
@@ -2018,7 +2132,6 @@
         "signal-exit": "^3.0.2",
         "spawn-wrap": "^2.0.0",
         "test-exclude": "^6.0.0",
-        "uuid": "^3.3.3",
         "yargs": "^15.0.2"
       },
       "dependencies": {
@@ -2029,12 +2142,11 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha1-kK51xCTQCNJiTFvynq0xd+v881k=",
+          "version": "4.3.0",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -2157,9 +2269,9 @@
           }
         },
         "yargs": {
-          "version": "15.3.1",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/yargs/-/yargs-15.3.1.tgz",
-          "integrity": "sha1-lQW0cnY5Y+VK/mAUitJ6MwgY6Ys=",
+          "version": "15.4.1",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/yargs/-/yargs-15.4.1.tgz",
+          "integrity": "sha1-DYehbeAa7p2L7Cv7909nhRcw9Pg=",
           "dev": true,
           "requires": {
             "cliui": "^6.0.0",
@@ -2172,13 +2284,13 @@
             "string-width": "^4.2.0",
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.1"
+            "yargs-parser": "^18.1.2"
           }
         },
         "yargs-parser": {
-          "version": "18.1.1",
-          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/yargs-parser/-/yargs-parser-18.1.1.tgz",
-          "integrity": "sha1-v3QHuRVCf8dg/LvMxsgrTw/8vTc=",
+          "version": "18.1.3",
+          "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha1-vmjEl1xrKr9GkjawyHA2L6sJp7A=",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -2188,9 +2300,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
+      "version": "1.8.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha1-34B+Xs9TpgnMa/6T6sPMe+WzqdA=",
       "dev": true
     },
     "object-keys": {
@@ -2212,13 +2324,14 @@
       }
     },
     "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
+      "version": "2.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.1.tgz",
+      "integrity": "sha1-Df2o0QgHTZxWPoBJDIg7ZmEJFUQ=",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "once": {
@@ -2231,9 +2344,9 @@
       }
     },
     "onetime": {
-      "version": "5.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/onetime/-/onetime-5.1.0.tgz",
-      "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
+      "version": "5.1.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha1-0Oluu1awdHbfHdnEgG5SN5hcpF4=",
       "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
@@ -2260,9 +2373,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "2.2.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/p-limit/-/p-limit-2.2.2.tgz",
-      "integrity": "sha1-YSebZ3IfUoeqHBOpp/u8SMkpGx4=",
+      "version": "2.3.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -2349,9 +2462,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha1-IbrIiLbthgH4Mc54FuM1vHefCko="
+      "version": "2.2.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha1-IfMz6ba46v8CRo9RRupAbTRfTa0="
     },
     "pkg-dir": {
       "version": "4.2.0",
@@ -2444,17 +2557,18 @@
       }
     },
     "readdirp": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha1-wwwzNSsSyW37S4lUIaSf1alZODk=",
+      "version": "3.5.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha1-m6dMAZsV02UnjS6Ru4xI17TULJ4=",
+      "optional": true,
       "requires": {
-        "picomatch": "^2.0.4"
+        "picomatch": "^2.2.1"
       }
     },
     "regexpp": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/regexpp/-/regexpp-3.0.0.tgz",
-      "integrity": "sha1-3WOYLuMwDme0HBlW+FCqaA2dMw4=",
+      "version": "3.1.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha1-IG0K0KVkjP+9uK5GQ489xRyfeOI=",
       "dev": true
     },
     "release-zalgo": {
@@ -2479,11 +2593,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha1-J73N7/6vLWJEuVuw+fS0ZTRR8+g=",
+      "version": "1.19.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha1-GvW/YwQJc0oGfK4pMYqsf6KaJnw=",
       "dev": true,
       "requires": {
+        "is-core-module": "^2.1.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -2513,18 +2628,15 @@
       }
     },
     "run-async": {
-      "version": "2.4.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/run-async/-/run-async-2.4.0.tgz",
-      "integrity": "sha1-5ZBUpbhods+uB/Qx0Yy63cWU8eg=",
-      "dev": true,
-      "requires": {
-        "is-promise": "^2.1.0"
-      }
+      "version": "2.4.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/run-async/-/run-async-2.4.1.tgz",
+      "integrity": "sha1-hEDsz5nqPnC9QJ1JqriOEMGJpFU=",
+      "dev": true
     },
     "rxjs": {
-      "version": "6.5.4",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/rxjs/-/rxjs-6.5.4.tgz",
-      "integrity": "sha1-4Hd/4NGEzseHLfFH8wNXLUFOIRw=",
+      "version": "6.6.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/rxjs/-/rxjs-6.6.3.tgz",
+      "integrity": "sha1-jKhGNcTaqQDA05Z6buesYCce5VI=",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
@@ -2548,9 +2660,9 @@
       "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
+      "version": "7.3.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/semver/-/semver-7.3.2.tgz",
+      "integrity": "sha1-YElisFK4HtB4aq6EOJ/7pw/9OTg=",
       "dev": true
     },
     "set-blocking": {
@@ -2575,9 +2687,9 @@
       "dev": true
     },
     "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "version": "3.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha1-oUEMLt2PB3sItOJTyOrPyvBXRhw=",
       "dev": true
     },
     "slice-ansi": {
@@ -2648,24 +2760,24 @@
         "strip-ansi": "^5.1.0"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-      "integrity": "sha1-m9uKxqvW1gKxek7TIYcNL43O/HQ=",
+    "string.prototype.trimend": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha1-oivVPMpcfPRNfJ1ccyEYhz1s0Ys=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
-    "string.prototype.trimright": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-      "integrity": "sha1-RAMUsVmWyGbOigNBiU1FGGIAxdk=",
+    "string.prototype.trimstart": {
+      "version": "1.0.3",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha1-m0y1kOEjuzZWRAHVmCQpjeUP1ao=",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "function-bind": "^1.1.1"
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string_decoder": {
@@ -2690,9 +2802,9 @@
       "dev": true
     },
     "strip-json-comments": {
-      "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
-      "integrity": "sha1-hXE5dakfuHvxswXMp3OV5A0qZKc=",
+      "version": "3.1.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha1-MfEoGzgyYwQ0gxwxDAHMzajL4AY=",
       "dev": true
     },
     "supports-color": {
@@ -2781,6 +2893,15 @@
         }
       }
     },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -2796,9 +2917,9 @@
       }
     },
     "tslib": {
-      "version": "1.11.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tslib/-/tslib-1.11.1.tgz",
-      "integrity": "sha1-6xXRKIJ/vuKEFUnhcfRe0zisfjU=",
+      "version": "1.14.1",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha1-zy04vcNKE0vK8QkcQfZhni9nLQA=",
       "dev": true
     },
     "tsutils": {
@@ -2841,15 +2962,15 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha1-QJ64VE6gM1cRIFhp7EWKsQnuEGE=",
+      "version": "3.9.7",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha1-mNYApevcOPQMsndSLxLcgA6eJfo=",
       "dev": true
     },
     "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "version": "4.4.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/uri-js/-/uri-js-4.4.0.tgz",
+      "integrity": "sha1-qnFCYd55PoqCNHp7zJznTobyhgI=",
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -2868,15 +2989,15 @@
       "dev": true
     },
     "v8-compile-cache": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
-      "integrity": "sha1-4U3jezGm0ZT1aQ1n78Tn9vxqsw4=",
+      "version": "2.2.0",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha1-lHHvo++RKNL3xqfKOcTda1BVsTI=",
       "dev": true
     },
     "vscode-uri": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/vscode-uri/-/vscode-uri-2.1.1.tgz",
-      "integrity": "sha1-WqGAM5G2690X0Ef1E2XPYsOPbpA="
+      "version": "2.1.2",
+      "resolved": "https://pkgs.dev.azure.com/slb-swt/_packaging/ai-planning/npm/registry/vscode-uri/-/vscode-uri-2.1.2.tgz",
+      "integrity": "sha1-yNQN6T61evMfPHFd1lDiyiwJbxw="
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,11 @@
   },
   "devDependencies": {
     "typescript": "^3.8.3",
-    "@types/node": "^13.9.1",
+    "@types/node": "^12.14.1",
     "@types/nunjucks": "^3.1.3",
     "@typescript-eslint/eslint-plugin": "^2.24.0",
     "@typescript-eslint/parser": "^2.24.0",
     "@types/mocha": "^7.0.2",
-    "@types/tmp": "^0.1.0",
     "@types/chai": "4.1.3",
     "@types/chai-string": "1.4.1",
     "chai": "^4.2.0",
@@ -43,7 +42,6 @@
     "nyc": "^15.0.0"
   },
   "dependencies": {
-    "tmp-promise": "2.0.2",
     "nunjucks": "^3.2.0",
     "xml2js": "^0.4.23",
     "parse-xsd-duration": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl-workspace",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "PDDL Workspace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/PlanInfo.ts
+++ b/src/PlanInfo.ts
@@ -10,6 +10,9 @@ import { PddlSyntaxTree } from "./parser/PddlSyntaxTree";
 import { DocumentPositionResolver } from "./DocumentPositionResolver";
 import { PddlLanguage } from "./language";
 import { URI } from "vscode-uri";
+import { ProblemInfo } from "./ProblemInfo";
+import { Plan } from "./Plan";
+import { DomainInfo } from "./DomainInfo";
 /**
  * Plan file.
  */
@@ -49,5 +52,8 @@ export class PlanInfo extends FileInfo {
     }
     getHappenings(): Happening[] {
         return PlanInfo.getHappenings(this.getSteps());
+    }
+    getPlan(domain: DomainInfo, problem: ProblemInfo): Plan {
+        return new Plan(this.getSteps(), domain, problem);
     }
 }

--- a/src/PreProcessors.ts
+++ b/src/PreProcessors.ts
@@ -6,7 +6,7 @@
 import * as process from 'child_process';
 import * as path from 'path';
 import * as nunjucks from 'nunjucks';
-import * as afs from './utils/asyncfs';
+import * as fs from 'fs';
 
 export interface OutputAdaptor {
     appendLine(text: string): void;
@@ -204,7 +204,7 @@ export class NunjucksPreProcessor extends PreProcessor {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     async transform(input: string, workingDirectory: string, _outputWindow: OutputAdaptor): Promise<string> {
         const dataPath = path.join(workingDirectory, this.dataFileName);
-        const dataText = await afs.readFile(dataPath);
+        const dataText = await fs.promises.readFile(dataPath);
         let data: unknown;
 
         try {

--- a/src/utils/asyncfs.ts
+++ b/src/utils/asyncfs.ts
@@ -5,17 +5,6 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
-import util = require('util');
-
-export const readFile = util.promisify(fs.readFile);
-export const writeFile = util.promisify(fs.writeFile);
-export const write = util.promisify(fs.write);
-export const exists = util.promisify(fs.exists);
-export const readdir = util.promisify(fs.readdir);
-export const unlink = util.promisify(fs.unlink);
-export const rmdir = util.promisify(fs.rmdir);
-export const stat = util.promisify(fs.stat);
-export const copyFile = util.promisify(fs.copyFile);
 
 /**
  * Creates directory (optionally recursively) 
@@ -41,7 +30,7 @@ export async function mkdirIfDoesNotExist(path: fs.PathLike, options: fs.MakeDir
  * @returns file name array with absolute path
  */
 export async function getFiles(dir: string): Promise<string[]> {
-    const dirents = await readdir(dir, { withFileTypes: true });
+    const dirents = await fs.promises.readdir(dir, { withFileTypes: true });
     const childrenFilePromises = dirents.map(dirent => {
         const res = path.resolve(dir, dirent.name);
         return dirent.isDirectory() ? getFiles(res) : Promise.resolve([res]);
@@ -55,11 +44,25 @@ export async function getFiles(dir: string): Promise<string[]> {
  * @param directory directory to test
  */
 export async function isEmpty(directory: string): Promise<boolean> {
-    const stats = await stat(directory);
+    const stats = await fs.promises.stat(directory);
     if (!stats.isDirectory()) {
         throw new Error("Not a directory: " + directory);
     }
 
-    const dirContent = await readdir(directory);
+    const dirContent = await fs.promises.readdir(directory);
     return dirContent.length === 0;
+}
+
+export async function exists(path: fs.PathLike): Promise<boolean> {
+    try {
+        await fs.promises.stat(path);
+    } catch (err) {
+        if (err.code === 'ENOENT') {
+            return false;
+        } else {
+            throw err;
+        }
+    }
+
+    return true;
 }

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -3,11 +3,6 @@
  * Licensed under the MIT License. See License.txt in the project root for license information.
  * ------------------------------------------------------------------------------------------ */
 
-import * as tmp from 'tmp-promise';
-import fs = require('fs');
-import * as afs from './asyncfs';
-
-
 export class Util {
 
     /**
@@ -25,26 +20,6 @@ export class Util {
             && !path.includes(" -jar ")
             && !path.includes(" -javaagent:")
             && !path.startsWith("node ");
-    }
-
-    static toFileSync(prefix: string, suffix: string, text: string): string {
-        const tempFile = tmp.fileSync({ mode: 0o644, prefix: prefix + '-', postfix: suffix });
-        fs.writeSync(tempFile.fd, text, 0, 'utf8');
-        return tempFile.name;
-    }
-
-    static async toFile(prefix: string, suffix: string, text: string): Promise<string> {
-        const tempFile = await tmp.file({ mode: 0o644, prefix: prefix + '-', postfix: suffix });
-        await afs.write(tempFile.fd, text, 0, 'utf8');
-        return tempFile.path;
-    }
-
-    static toPddlFileSync(prefix: string, text: string): string {
-        return Util.toFileSync(prefix, '.pddl', text);
-    }
-
-    static async toPddlFile(prefix: string, text: string): Promise<string> {
-        return Util.toFile(prefix, '.pddl', text);
     }
 
     /**


### PR DESCRIPTION
Upgrade to Node 12.14.1. 
Replaced async `fs` by the `fs.promises` equivalents. 
Convenience `PlanInfo.getPlan()`
Breaking change: removed `fs` dependency, so this package runs in a browser. Functionality was moved to the _ai-planning-val.js_ package.