### PR TITLE
plan JSON re-hydration

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,5 @@
 			]
 		}
 	},
-    "mocha.files.glob": "out/test/**/*.js"
+	"mocha.files.glob": "out/test/**/*Test.js"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl-workspace",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "PDDL Workspace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "mocha -- out/test/**/*.js",
+    "test": "mocha -- out/test/**/*Test.js",
     "pretest": "eslint ./src/**/*.ts && npm run compile",
     "build": "tsc",
     "compile": "tsc && npm run copyToDist",

--- a/src/DocumentPositionResolver.ts
+++ b/src/DocumentPositionResolver.ts
@@ -70,6 +70,10 @@ export class PddlRange {
         return new PddlRange({ start: new PddlPosition(line, 0), end: new PddlPosition(line, Number.MAX_VALUE) });
     }
 
+    static createUnknown(): PddlRange {
+        return this.createFullLineRange(Number.NaN);
+    }
+
     includes(positionAtOffset: PddlPosition): boolean {
         return this.start.atOrBefore(positionAtOffset) && positionAtOffset.atOrBefore(this.end);
     }

--- a/src/DomainInfo.ts
+++ b/src/DomainInfo.ts
@@ -171,7 +171,7 @@ export class DomainInfo extends FileInfo {
     static cloneAction(action: Action): Action {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const actionAny = action as any;
-        if (actionAny.hasOwnPropery('duration')) {
+        if ('duration' in actionAny) {
             return new DurativeAction(action.name, action.parameters, PddlRange.createUnknown());
         } else {
             return new InstantAction(action.name, action.parameters, PddlRange.createUnknown());

--- a/src/PddlWorkspace.ts
+++ b/src/PddlWorkspace.ts
@@ -266,7 +266,7 @@ export class PddlWorkspace extends EventEmitter {
             return unknownFile;
         }
         else if (language === PddlLanguage.PLAN) {
-            return PddlPlanParser.parseText(fileText, this.epsilon, fileUri, fileVersion, positionResolver);
+            return new PddlPlanParser().parseText(fileText, this.epsilon, fileUri, fileVersion, positionResolver);
         }
         else if (language === PddlLanguage.HAPPENINGS) {
             return new HappeningsParser().parseHappenings(fileUri, fileVersion, fileText, this.epsilon, positionResolver);

--- a/src/Plan.ts
+++ b/src/Plan.ts
@@ -11,7 +11,7 @@ import { DomainInfo } from './DomainInfo';
 export class Plan {
     private _makespan: number;
     statesEvaluated?: number;
-    private _cost?: number;
+    private _metric?: number;
 
     constructor(public readonly steps: PlanStep[], public readonly domain?: DomainInfo,
         public readonly problem?: ProblemInfo,
@@ -36,27 +36,42 @@ export class Plan {
             plan.helpfulActions
         );
 
-        plan._cost && (clonedPlan.cost = plan._cost);
+        plan._metric && (clonedPlan.metric = plan._metric);
         clonedPlan.statesEvaluated = plan.statesEvaluated;
 
         return clonedPlan;
     }
 
+    /** @deprecated use `metric` */
     get cost(): number {
-        // if cost was not output by the planning engine, use the plan makespan
-        return this._cost ?? this._makespan;
+        return this.metric;
     }
 
-    set cost(cost: number) {
-        this._cost = cost;
+    /** @deprecated use `metric` */
+    set cost(metric: number) {
+        this.metric = metric;
+    }
+
+    get metric(): number {
+        // if cost was not output by the planning engine, use the plan makespan
+        return this._metric ?? this._makespan;
+    }
+
+    set metric(metric: number) {
+        this._metric = metric;
     }
 
     get makespan(): number {
         return this._makespan;
     }
 
+    isMetricDefined(): boolean {
+        return this._metric !== undefined;
+    }
+
+    /** @deprecated use isMetricDefined */
     isCostDefined(): boolean {
-        return this._cost !== undefined;
+        return this.isMetricDefined();
     }
 
     /**

--- a/src/PlanInfo.ts
+++ b/src/PlanInfo.ts
@@ -18,6 +18,9 @@ import { DomainInfo } from "./DomainInfo";
  */
 export class PlanInfo extends FileInfo {
     steps: PlanStep[] = [];
+    private _metric: number | undefined;
+    private _statesEvaluated: number | undefined;
+
     constructor(fileUri: URI, version: number, public problemName: string, public domainName: string, text: string, positionResolver: DocumentPositionResolver) {
         // note we use the `problemName` as the plan name as the plan does not have any declared name
         super(fileUri, version, problemName, PddlSyntaxTree.EMPTY, positionResolver);
@@ -32,6 +35,21 @@ export class PlanInfo extends FileInfo {
     getSteps(): PlanStep[] {
         return this.steps;
     }
+
+    get metric(): number | undefined {
+        return this._metric;
+    }
+    set metric(metric: number | undefined){
+        this._metric = metric;
+    }
+
+    get statesEvaluated(): number | undefined {
+        return this._statesEvaluated;
+    }
+    set statesEvaluated(statesEvaluated: number | undefined){
+        this._statesEvaluated = statesEvaluated;
+    }
+    
     isPlan(): boolean {
         return true;
     }

--- a/src/PlanStep.ts
+++ b/src/PlanStep.ts
@@ -18,6 +18,18 @@ export class PlanStep {
         this.objects = nameFragments.slice(1);
     }
 
+    static clone(planStep: PlanStep): PlanStep {
+        return new PlanStep(
+            planStep.time,
+            planStep.fullActionName,
+            planStep.isDurative,
+            planStep.duration,
+            planStep.lineIndex,
+            planStep.commitment,
+            planStep.iterations
+        );
+    }
+
     getActionName(): string {
         return this.actionName;
     }

--- a/src/ProblemInfo.ts
+++ b/src/ProblemInfo.ts
@@ -6,7 +6,7 @@
 import { FileInfo } from "./FileInfo";
 import { PreProcessor } from "./PreProcessors";
 import { PddlSyntaxTree } from "./parser/PddlSyntaxTree";
-import { DocumentPositionResolver, PddlRange } from "./DocumentPositionResolver";
+import { DocumentPositionResolver, PddlRange, SimpleDocumentPositionResolver } from "./DocumentPositionResolver";
 import { TypeObjectMap } from "./DomainInfo";
 import { Constraint } from "./constraints";
 import { PddlLanguage } from "./language";
@@ -102,6 +102,24 @@ export class ProblemInfo extends FileInfo {
 
     constructor(fileUri: URI, version: number, problemName: string, public domainName: string, readonly syntaxTree: PddlSyntaxTree, positionResolver: DocumentPositionResolver) {
         super(fileUri, version, problemName, syntaxTree, positionResolver);
+    }
+
+    /**
+     * Copy constructor for re-constructing the problem from a serialized form.
+     * @param problem de-serialized problem
+     * @param domainName domain name
+     */
+    static clone(problem: ProblemInfo, domainName: string): ProblemInfo {
+        const clonedProblem = new ProblemInfo(problem.fileUri, Number.NaN, problem.name, domainName,
+            PddlSyntaxTree.EMPTY, new SimpleDocumentPositionResolver(''));
+
+        clonedProblem.setConstraints(problem.constraints);
+        clonedProblem.setInits(problem.inits);
+        clonedProblem.setMetrics(problem.metrics);
+        clonedProblem.setObjects(TypeObjectMap.clone(problem.objects));
+        clonedProblem.setSupplyDemands(problem.supplyDemands);
+        
+        return clonedProblem;
     }
 
     setPreParsingPreProcessor(preProcessor: PreProcessor): void {

--- a/src/parser/NormalizingPddlPlanParser.ts
+++ b/src/parser/NormalizingPddlPlanParser.ts
@@ -1,0 +1,78 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Jan Dolejsi 2021. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { PlanStep } from "../PlanStep";
+import { PddlPlanBuilder } from "./PddlPlanBuilder";
+import { PddlPlanParser } from "./PddlPlanParser";
+
+/** Parsers the plan lines, offsets the times (by epsilon, if applicable) and returns the lines normalized. */
+export class NormalizingPddlPlanParser {
+
+    private makespan = 0;
+    private timeOffset = 0;
+    private firstLineParsed = false;
+
+    constructor(private epsilon: number) {
+
+    }
+
+    /**
+     * Parses and normalizes the plan text (typically for plan comparison).
+     * If the plan starts at time zero, it is shifted to time `epsilon`.
+     * 
+     * @param origText original plan text
+     * @param endl platform-specific end-line characters
+     */
+    normalize(origText: string, endl: string): string {
+        const compare = function (step1: PlanStep, step2: PlanStep): number {
+            if (step1.getStartTime() !== step2.getStartTime()) {
+                return step1.getStartTime() - step2.getStartTime();
+            }
+            else {
+                return step1.fullActionName.localeCompare(step2.fullActionName);
+            }
+        };
+
+        const planMeta = PddlPlanParser.parsePlanMeta(origText);
+        const planParser = new PddlPlanParser();
+        const planBuilder = new PddlPlanBuilder(this.epsilon);
+
+        const normalizedText = PddlPlanParser.getPlanMeta(planMeta.domainName, planMeta.problemName, endl)
+            + `${endl}; Normalized plan:${endl}`
+            + origText.split('\n')
+                .map((origLine, idx) => this.normalizeLine(origLine, idx, planParser, planBuilder))
+                .filter(step => step !== undefined)
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                .map(step => step!)
+                .sort(compare)
+                .map(step => step.toPddl())
+                .join(endl);
+
+        return normalizedText;
+    }
+
+    protected normalizeLine(line: string, lineIdx: number, planParser: PddlPlanParser, planBuilder: PddlPlanBuilder): PlanStep | undefined {
+
+        const planStep = planParser.parse(line, lineIdx, planBuilder);
+
+        if (!planStep) {
+            return undefined;
+        } else {
+            // this line is a plan step
+            const time = planStep.getStartTime();
+
+            if (!this.firstLineParsed) {
+                if (time === 0) {
+                    this.timeOffset = -this.epsilon;
+                }
+                this.firstLineParsed = true;
+            }
+
+            return new PlanStep(time - this.timeOffset, planStep.getFullActionName(),
+                planStep.isDurative, planStep.getDuration(),
+                planStep.lineIndex);
+        }
+    }
+}

--- a/src/parser/PddlPlanBuilder.ts
+++ b/src/parser/PddlPlanBuilder.ts
@@ -7,7 +7,6 @@ import { Plan } from '../Plan';
 import { PlanStep } from '../PlanStep';
 import { ProblemInfo } from '../ProblemInfo';
 import { DomainInfo } from '../DomainInfo';
-import { PddlPlannerOutputParser } from './PddlPlannerOutputParser';
 
 /**
  * Utility for incremental plan building as it is being parsed.
@@ -17,26 +16,10 @@ export class PddlPlanBuilder {
     private metric: number | undefined;
     private steps: PlanStep[] = [];
     outputText = ""; // for information only
-    parsingPlan = false;
+    parsingPlan = false; // todo: move to PddlPlannerOutputParser
     private makespan = 0;
-    constructor(private epsilon: number) { }
-    parse(planLine: string, lineIndex: number | undefined): PlanStep | undefined {
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        PddlPlannerOutputParser.planStepPattern.lastIndex = 0;
-        // eslint-disable-next-line @typescript-eslint/no-use-before-define
-        const group = PddlPlannerOutputParser.planStepPattern.exec(planLine);
-        if (group) {
-            // this line is a valid plan step
-            const time = group[2] ? parseFloat(group[2]) : this.getMakespan();
-            const action = group[3];
-            const isDurative = group[5] ? true : false;
-            const duration = isDurative ? parseFloat(group[5]) : this.epsilon;
-            return new PlanStep(time, action, isDurative, duration, lineIndex);
-        }
-        else {
-            return undefined;
-        }
-    }
+    constructor(public readonly epsilon: number) { }
+
     add(step: PlanStep): void {
         if (this.makespan < step.getEndTime()) {
             this.makespan = step.getEndTime();
@@ -50,7 +33,7 @@ export class PddlPlanBuilder {
         const plan = new Plan(this.steps, domain, problem);
         plan.statesEvaluated = this.statesEvaluated;
         if (this.metric !== undefined) {
-            plan.cost = this.metric;
+            plan.metric = this.metric;
         }
         return plan;
     }

--- a/src/parser/PddlPlanBuilder.ts
+++ b/src/parser/PddlPlanBuilder.ts
@@ -16,7 +16,7 @@ export class PddlPlanBuilder {
     private metric: number | undefined;
     private steps: PlanStep[] = [];
     outputText = ""; // for information only
-    parsingPlan = false; // todo: move to PddlPlannerOutputParser
+    parsingPlan = false;
     private makespan = 0;
     constructor(public readonly epsilon: number) { }
 

--- a/src/parser/PddlPlanParser.ts
+++ b/src/parser/PddlPlanParser.ts
@@ -7,6 +7,7 @@ import { PlanInfo } from '../PlanInfo';
 import { PddlPlanBuilder } from './PddlPlanBuilder';
 import { DocumentPositionResolver, SimpleDocumentPositionResolver } from '../DocumentPositionResolver';
 import { URI } from 'vscode-uri';
+import { PlanStep } from '../PlanStep';
 
 export const UNSPECIFIED_PROBLEM = 'unspecified';
 export const UNSPECIFIED_DOMAIN = 'unspecified';
@@ -18,6 +19,10 @@ export interface PlanMetaData {
 }
 
 export class PddlPlanParser {
+
+    private readonly planStepPattern = /^\s*((\d+|\d+\.\d+)\s*:)?\s*\((.*)\)\s*(\[(?:D:)?\s*(\d+|\d+\.\d+)\s*(?:;\s*C:[\d.]+)?\])?\s*$/gim;
+    private readonly planStatesEvaluatedPattern = /^\s*;?\s*States evaluated[\w ]*:[ ]*(\d*)\s*$/i;
+    private readonly planMetricPattern = /[\w ]*(cost|metric)[^-\w]*:?\s*([+-]?\d*(\.\d+)?|[+-]?\d(\.\d+)?[Ee][+-]?\d+)\s*$/i;
 
     static parsePlanMeta(fileText: string): PlanMetaData {
         let problemName = UNSPECIFIED_PROBLEM;
@@ -35,21 +40,69 @@ export class PddlPlanParser {
         return { domainName: domainName, problemName: problemName };
     }
     
-    static parseText(planText: string, epsilon = 0.001, fileUri = URI.parse('string://noname'), fileVersion = -1, positionResolver?: DocumentPositionResolver): PlanInfo {
+    static getPlanMeta(domainName: string, problemName: string, endl: string): string {
+        return `;;!domain: ${domainName}${endl};;!problem: ${problemName}${endl}`;
+    }
+
+    parseText(planText: string, epsilon = 0.001, fileUri = URI.parse('string://noname'), fileVersion = -1, positionResolver?: DocumentPositionResolver): PlanInfo {
         const meta = PddlPlanParser.parsePlanMeta(planText);
 
         const definedPositionResolver = positionResolver ?? new SimpleDocumentPositionResolver(planText);
 
         const planInfo = new PlanInfo(fileUri, fileVersion, meta.problemName, meta.domainName, planText, definedPositionResolver);
         const planBuilder = new PddlPlanBuilder(epsilon);
-        planText.split('\n').forEach((planLine: string, index: number) => {
-            const planStep = planBuilder.parse(planLine, index);
-            if (planStep) {
-                planBuilder.add(planStep);
-            }
-        });
+        planText.split('\n').forEach((planLine: string, index: number) =>
+            this.tryParseLine(planLine, index, planBuilder));
         planInfo.setSteps(planBuilder.getSteps());
 
+        planInfo.metric = planBuilder.getMetric();
+        planInfo.statesEvaluated = planBuilder.getStatesEvaluated();
+
         return planInfo;
+    }
+
+    private tryParseLine(planLine: string, index: number, planBuilder: PddlPlanBuilder): void {
+        const planStep = this.parse(planLine, index, planBuilder);
+        if (planStep) {
+            planBuilder.add(planStep);
+        } else {
+            this.parsePlanQuality(planLine, planBuilder);
+        }
+    }
+    
+    /**
+     * Parses one line from the plan
+     * @param planLine line of text from the plan file
+     * @param lineIndex index of the line being parsed
+     */
+    parse(planLine: string, lineIndex: number | undefined, planBuilder: PddlPlanBuilder): PlanStep | undefined {
+        this.planStepPattern.lastIndex = 0;
+        const group = this.planStepPattern.exec(planLine);
+        if (group) {
+            // this line is a valid plan step
+            const time = group[2] ? parseFloat(group[2]) : planBuilder.getMakespan();
+            const action = group[3];
+            const isDurative = group[5] ? true : false;
+            const duration = isDurative ? parseFloat(group[5]) : planBuilder.epsilon;
+            return new PlanStep(time, action, isDurative, duration, lineIndex);
+        }
+        else {
+            return undefined;
+        }
+    }
+
+    parsePlanQuality(planLine: string, planBuilder: PddlPlanBuilder): void {
+        let group: RegExpExecArray | null;
+        this.planStatesEvaluatedPattern.lastIndex = 0;
+        this.planMetricPattern.lastIndex = 0;
+        if (group = this.planStatesEvaluatedPattern.exec(planLine)) {
+            planBuilder.setStatesEvaluated(parseInt(group[1]));
+        }
+        else if (!planLine.match(/action/i) &&
+            (group = this.planMetricPattern.exec(planLine))) {
+            if (group[2]?.length > 0) {
+                planBuilder.setMetric(parseFloat(group[2]));
+            }
+        }
     }
 }

--- a/src/parser/PddlProblemParser.ts
+++ b/src/parser/PddlProblemParser.ts
@@ -48,13 +48,13 @@ export class PddlProblemParser extends PddlFileParser<ProblemInfo> {
     }
 
     async tryParse(fileUri: URI, fileVersion: number, fileText: string, syntaxTree: PddlSyntaxTree, positionResolver: DocumentPositionResolver): Promise<ProblemInfo | undefined> {
-        const filePath = fileUri.fsPath;
-        const workingDirectory = dirname(filePath);
         let preProcessor: PreProcessor | undefined;
 
         if (this.problemPreParser) {
             try {
                 preProcessor = this.problemPreParser.createPreProcessor(fileText);
+                const filePath = fileUri.fsPath;
+                const workingDirectory = dirname(filePath);
                 fileText = await this.problemPreParser.process(preProcessor!, fileText, workingDirectory);
             } catch (ex) {
                 const problemInfo = new ProblemInfo(fileUri, fileVersion, "unknown", "unknown", PddlSyntaxTree.EMPTY, positionResolver);

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -18,8 +18,10 @@ export * from './PddlStructure';
 export * from './PddlTokenizer';
 
 export * from './PddlPlanParser';
+export * from './PddlPlanBuilder';
 export * from './PddlPlannerOutputParser';
 export * from './PlanValuesParser';
+export * from './NormalizingPddlPlanParser';
 
 export * from './HappeningsParser';
 export * from './PlanHappeningsBuilder';

--- a/src/utils/DirectionalGraph.ts
+++ b/src/utils/DirectionalGraph.ts
@@ -8,7 +8,22 @@
  */
 export class DirectionalGraph {
     // vertices and edges stemming from them
-    verticesAndEdges: [string, string[]][] = [];
+    private verticesAndEdges: [string, string[]][] = [];
+
+    /**
+     * Constructor, optionally copy-constructor.
+     * @param verticesAndEdges optional list of vertex-edges tuples - use as a copy constructor to re-hydrate from de-serialized object
+     */
+    constructor(verticesAndEdges?: [string, string[]][]) {
+        if (verticesAndEdges) {
+            this.verticesAndEdges = verticesAndEdges;
+        }
+    }
+
+    static fromGraph(graph: DirectionalGraph): DirectionalGraph {
+        return new DirectionalGraph(graph.verticesAndEdges);
+    }
+
     /**
      * Get all vertices.
      */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { Util } from './util';
 export { StringifyingMap } from './StringifyingMap';
 export { DirectionalGraph } from './DirectionalGraph';
+export * as serializationUtils from './serializationUtils';
 import * as afs from './asyncfs';
 export { afs };  // until Typescript 3.8

--- a/src/utils/serializationUtils.ts
+++ b/src/utils/serializationUtils.ts
@@ -1,0 +1,67 @@
+/* --------------------------------------------------------------------------------------------
+* Copyright (c) Jan Dolejsi 2020. All rights reserved.
+* Licensed under the MIT License. See License.txt in the project root for license information.
+* ------------------------------------------------------------------------------------------ */
+
+/* eslint-disable @typescript-eslint/no-use-before-define */
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function asSerializable(obj: any): any {
+    if (obj instanceof Map) {
+        return strMapToObj(obj);
+    }
+    else if (obj instanceof Array) {
+        return obj.map(o => asSerializable(o));
+    }
+    else if (obj instanceof Set) {
+        return [...obj].map(o => asSerializable(o));
+    }
+    else if (obj instanceof Object) {
+        const serObj = Object.create(null);
+        Object.keys(obj).forEach(key => serObj[key] = asSerializable(obj[key]));
+        return serObj;
+    }
+    else {
+        return obj;
+    }
+}
+
+export function strMapToObj(strMap: Map<string, unknown>): unknown {
+    const obj = Object.create(null);
+    for (const [k, v] of strMap) {
+        obj[k] = asSerializable(v);
+    }
+    return obj;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function objToStrMap(obj: any): Map<string, any> {
+    const strMap = new Map();
+    for (const k of Object.keys(obj)) {
+        strMap.set(k, obj[k]);
+    }
+    return strMap;
+}
+
+/**
+ * Removes circular dependencies to make JSON-serialization safe.
+ * @param orig original object
+ */
+export function makeSerializable<T>(orig: T): T {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const getCircularReplacer = (): any => {
+        const seen = new WeakSet();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (_key: any, value: any): any => {
+          if (typeof value === "object" && value !== null) {
+            if (seen.has(value)) {
+              return;
+            }
+            seen.add(value);
+          }
+          return value;
+        };
+      };
+      
+    return JSON.parse(JSON.stringify(orig, getCircularReplacer()));
+}

--- a/test/PlanStepTest.ts
+++ b/test/PlanStepTest.ts
@@ -3,20 +3,39 @@ import { PlanStep, PlanStepCommitment } from "./src";
 const expect = require('chai').expect;
 
 describe("PlanStep", () => {
-    describe("defaults to 1 iteration", () => {
-        const planStep = new PlanStep(0.001, 'action1', true, 10, undefined);
-        expect(planStep.isDurative).to.be.equal(true);
-        expect(planStep.getDuration()).to.be.equal(10);
-        expect(planStep.getIterations()).to.be.equal(1);
+    describe("#constructor", () => {
+        it('defaults to 1 iteration', () => {
+            const planStep = new PlanStep(0.001, 'action1', true, 10, undefined);
+            expect(planStep.isDurative).to.be.equal(true);
+            expect(planStep.getDuration()).to.be.equal(10);
+            expect(planStep.getIterations()).to.be.equal(1);
+        });
     });
 
-    describe("returns iterations", () => {
-        const iterations = 2;
-        const commitment = PlanStepCommitment.StartsInRelaxedPlan;
+    describe("#getIterations", () => {
+        it('returns n iterations', () => {
+            const iterations = 2;
+            const commitment = PlanStepCommitment.StartsInRelaxedPlan;
 
-        const planStep = new PlanStep(0.001, 'action1', true, 10, undefined, commitment, iterations);
-        
-        expect(planStep.commitment).to.be.equal(commitment);
-        expect(planStep.getIterations()).to.be.equal(iterations);
+            const planStep = new PlanStep(0.001, 'action1', true, 10, undefined, commitment, iterations);
+
+            expect(planStep.commitment).to.be.equal(commitment);
+            expect(planStep.getIterations()).to.be.equal(iterations);
+        });
+    });
+
+    describe("#clone", () => {
+        it('clones', () => {
+            const iterations = 2;
+            const commitment = PlanStepCommitment.StartsInRelaxedPlan;
+
+            const planStep = new PlanStep(0.001, 'action1', true, 10, undefined, commitment, iterations);
+
+            const actual = PlanStep.clone(planStep);
+
+            expect(actual).to.not.be.undefined;
+            expect(actual.commitment).to.be.equal(commitment);
+            expect(planStep.getIterations()).to.be.equal(iterations);
+        });
     });
 });

--- a/test/PlanTest.ts
+++ b/test/PlanTest.ts
@@ -1,0 +1,64 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Jan Dolejsi. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { URI } from "vscode-uri";
+import { PddlSyntaxTree, } from "./parser/src";
+import {
+    Plan, PlanStep, HelpfulAction, HappeningType, PddlRange, InstantAction, DomainInfo,
+    TypeObjectMap, ProblemInfo, DocumentPositionResolver, SimpleDocumentPositionResolver
+} from "./src";
+import { DirectionalGraph } from './utils/src';
+
+const expect = require('chai').expect;
+
+function createPositionResolver(): DocumentPositionResolver {
+    return new SimpleDocumentPositionResolver('');
+}
+
+describe("Plan", () => {
+    describe("#clone", () => {
+        it('clones', () => {
+            const planStep = new PlanStep(0.001, 'action1', true, 10, undefined);
+            const helpfulAction: HelpfulAction = {
+                actionName: "Helpful",
+                kind: HappeningType.INSTANTANEOUS
+            };
+            const domain = new DomainInfo(URI.parse("file:///fake"), 1, "domain1", PddlSyntaxTree.EMPTY, createPositionResolver());
+            domain.setActions([new InstantAction("action1", [], PddlRange.createFullLineRange(0))]);
+            domain.setTypeInheritance(new DirectionalGraph().addEdge("type1", "object"));
+            const problem = new ProblemInfo(URI.parse("file:///fake"), 1, "problem1", "domain1", PddlSyntaxTree.EMPTY, createPositionResolver());
+            problem.setObjects(new TypeObjectMap().add("type1", "obj1"));
+
+            const cost = 123.456;
+            const statesEvaluated = 111;
+
+            const plan = new Plan([planStep], domain, problem, 13, [helpfulAction]);
+            plan.cost = cost;
+            plan.statesEvaluated = statesEvaluated;
+
+            const wiredPlan = JSON.parse(JSON.stringify(plan));
+
+            // WHEN
+
+            const actual = Plan.clone(wiredPlan);
+
+            // THEN
+            expect(actual).to.not.be.undefined;
+            expect(actual.cost).to.equal(cost);
+            expect(actual.steps).to.be.deep.equal([planStep]);
+            expect(actual.helpfulActions).to.be.deep.equal([helpfulAction]);
+            expect(actual.makespan).to.be.equal(plan.makespan);
+            expect(actual.statesEvaluated).to.be.equal(plan.statesEvaluated);
+            expect(actual.domain?.getActions().map(a => a.getNameOrEmpty())).to.deep.equal(plan.domain?.getActions().map(a => a.getNameOrEmpty()));
+            expect(actual.domain?.getTypes()).to.deep.equal(["type1"]);
+            // expect(actual.problem?.getObjectsTypeMap()).to.be.deep.equal(plan.problem?.getObjectsTypeMap());
+            expect(actual.problem?.getObjects("type1")).to.deep.equal(["obj1"]);
+
+            const allTypeObjects = plan.problem && actual.domain?.getConstants().merge(plan.problem?.getObjectsTypeMap());
+            expect(allTypeObjects).to.not.be.undefined;
+            expect(allTypeObjects?.getTypeOf("obj1")?.type).to.equal('type1');
+        });
+    });
+});

--- a/test/PlanTest.ts
+++ b/test/PlanTest.ts
@@ -31,11 +31,11 @@ describe("Plan", () => {
             const problem = new ProblemInfo(URI.parse("file:///fake"), 1, "problem1", "domain1", PddlSyntaxTree.EMPTY, createPositionResolver());
             problem.setObjects(new TypeObjectMap().add("type1", "obj1"));
 
-            const cost = 123.456;
+            const metric = 123.456;
             const statesEvaluated = 111;
 
             const plan = new Plan([planStep], domain, problem, 13, [helpfulAction]);
-            plan.cost = cost;
+            plan.metric = metric;
             plan.statesEvaluated = statesEvaluated;
 
             const wiredPlan = JSON.parse(JSON.stringify(plan));
@@ -46,7 +46,7 @@ describe("Plan", () => {
 
             // THEN
             expect(actual).to.not.be.undefined;
-            expect(actual.cost).to.equal(cost);
+            expect(actual.metric).to.equal(metric);
             expect(actual.steps).to.be.deep.equal([planStep]);
             expect(actual.helpfulActions).to.be.deep.equal([helpfulAction]);
             expect(actual.makespan).to.be.equal(plan.makespan);

--- a/test/parser/NormalizingPddlPlanParserTest.ts
+++ b/test/parser/NormalizingPddlPlanParserTest.ts
@@ -1,0 +1,115 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Jan Dolejsi. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+
+import { expect } from 'chai';
+import { PlanStep } from '../src';
+import { PddlPlanBuilder, PddlPlanParser, NormalizingPddlPlanParser } from './src';
+
+class TestableNormalizingPddlPlanParser extends NormalizingPddlPlanParser {
+
+    normalizeLine(line: string, lineIdx: number, planParser: PddlPlanParser, planBuilder: PddlPlanBuilder): PlanStep | undefined {
+        return super.normalizeLine(line, lineIdx, planParser, planBuilder);
+    }
+}
+
+describe('NormalizingPddlPlanParser', () => {
+
+    describe('#normalize', () => {
+
+        it('parses epsilon-starting plan', () => {
+            // GIVEN
+            const makespan = 0.001;
+            const cost = 0.12345;
+            const states = 1;
+            const epsilon = 0.1;
+            const endl = '\n';
+
+            const planText = [
+                `;;!domain: domain1`,
+                `;;!problem: problem1`,
+                ``,
+                `${epsilon}00: (a)`,
+                ``,
+                `; Makespan: ${makespan}`,
+                `; Cost: ${cost}`,
+                `; States evaluated: ${states}`
+            ].join(endl);
+
+            // WHEN
+            const normalizedPlanText = new NormalizingPddlPlanParser(epsilon).normalize(planText, endl);
+
+            // THEN
+            const expected = [`;;!domain: domain1`,
+                `;;!problem: problem1`,
+                ``,
+                `; Normalized plan:`,
+                `${epsilon}0000: (a)`,
+            ].join(endl);
+
+            expect(normalizedPlanText).to.equal(expected, "normalized plan");
+        });
+    });
+
+    describe('#normalizeLine', () => {
+
+        it('does not modify epsilon-starting action', () => {
+            // GIVEN
+            const epsilon = 0.1;
+
+            const planStepText = `${epsilon}00: (a)`;
+
+            // WHEN
+            const planParser = new PddlPlanParser();
+            const planBuilder = new PddlPlanBuilder(epsilon);
+            const actualPlanStep = new TestableNormalizingPddlPlanParser(epsilon).normalizeLine(planStepText, 0, planParser, planBuilder);
+
+            // THEN
+            expect(actualPlanStep).to.not.be.undefined;
+            expect(actualPlanStep?.getStartTime()).to.equal(epsilon, "start time");
+            expect(actualPlanStep?.isDurative).to.equal(false);
+        });
+
+        it('does not modify late-starting action', () => {
+            // GIVEN
+            const epsilon = 0.1;
+            const late = 10;
+            const duration = 1;
+            const planStepText = `${late}: (a) [${duration}]`;
+
+            // WHEN
+            const planParser = new PddlPlanParser();
+            const planBuilder = new PddlPlanBuilder(epsilon);
+            const actualPlanStep = new TestableNormalizingPddlPlanParser(epsilon).normalizeLine(planStepText, 0, planParser, planBuilder);
+
+            // THEN
+            expect(actualPlanStep).to.not.be.undefined;
+            expect(actualPlanStep?.getStartTime()).to.equal(late, "start time");
+            expect(actualPlanStep?.isDurative).to.equal(true);
+            expect(actualPlanStep?.getEndTime()).to.equal(late+duration, "end time");
+            expect(actualPlanStep?.getDuration()).to.equal(duration, "duration");
+        });
+
+        it('does modifies zero-starting action', () => {
+            // GIVEN
+            const epsilon = 0.1;
+            const zero = 0;
+            const duration = 1;
+            const planStepText = `${zero}: (a) [${duration}]`;
+
+            // WHEN
+            const planParser = new PddlPlanParser();
+            const planBuilder = new PddlPlanBuilder(epsilon);
+            const actualPlanStep = new TestableNormalizingPddlPlanParser(epsilon).normalizeLine(planStepText, 0, planParser, planBuilder);
+
+            // THEN
+            expect(actualPlanStep).to.not.be.undefined;
+            expect(actualPlanStep?.getStartTime()).to.equal(epsilon, "start time is postponed till epsilon");
+            expect(actualPlanStep?.isDurative).to.equal(true);
+            expect(actualPlanStep?.getEndTime()).to.equal(epsilon+duration, "end time");
+            expect(actualPlanStep?.getDuration()).to.equal(duration, "duration");
+        });
+    });
+});
+

--- a/test/parser/PddlPlanParserTest.ts
+++ b/test/parser/PddlPlanParserTest.ts
@@ -15,31 +15,38 @@ describe('PddlPlanParser', () => {
 
         it('parses non-temporal plan', () => {
             // GIVEN
+            const makespan = 0.001;
+            const cost = 0.12345;
+            const states = 1;
+
             const planText = `;;!domain: domain1
             ;;!problem: problem1
             
             0.00100: (a)
             
-            ; Makespan: 0.001
-            ; Cost: 0.001
-            ; States evaluated: 1`;
+            ; Makespan: ${makespan}
+            ; Cost: ${cost}
+            ; States evaluated: ${states}`;
 
             const fileUri = URI.parse('file://directory/file1.plan');
             const epsilon = 0.1;
             // WHEN
-            const planInfo = PddlPlanParser.parseText(planText, epsilon, fileUri, 33);
+            const version = 33;
+            const planInfo = new PddlPlanParser().parseText(planText, epsilon, fileUri, version);
 
             // THEN
             expect(planInfo).to.not.be.undefined;;
-            assert.strictEqual(planInfo?.fileUri, fileUri);
+            expect(planInfo?.fileUri).to.equal(fileUri);
             const expectedHappening = new Happening(0.001, HappeningType.INSTANTANEOUS, 'a', 0, 0);
-            assert.deepStrictEqual(planInfo?.getHappenings(), [expectedHappening], 'there should be 1 happening');
-            assert.strictEqual(planInfo?.getLanguage(), PddlLanguage.PLAN, 'the language should be plan');
-            assert.deepStrictEqual(planInfo?.isPlan(), true, 'this should be a plan');
-            assert.deepStrictEqual(planInfo?.getParsingProblems(), [], 'there should be no parsing issues');
-            assert.deepStrictEqual(planInfo?.getVersion(), 33, 'version');
+            expect(planInfo?.getHappenings()).to.deep.equal([expectedHappening], 'there should be 1 happening');
+            expect(planInfo?.getLanguage()).to.equal(PddlLanguage.PLAN, 'the language should be plan');
+            expect(planInfo?.isPlan()).to.equal(true, 'this should be a plan');
+            expect(planInfo?.getParsingProblems()).to.deep.equal([], 'there should be no parsing issues');
+            expect(planInfo?.getVersion()).to.equal(version, 'version');
             const expectedStep = new PlanStep(0.001, 'a', false, epsilon, 3);
-            assert.deepStrictEqual(planInfo?.getSteps(), [expectedStep], 'this should be a plan');
+            expect(planInfo?.getSteps()).to.deep.equal([expectedStep], 'this should be a plan');
+            expect(planInfo?.metric).to.equal(cost, "cost");
+            expect(planInfo?.statesEvaluated).to.equal(states, "states evaluated");
         });
 
         it('parses temporal plan', () => {
@@ -56,7 +63,7 @@ describe('PddlPlanParser', () => {
             const fileUri = URI.parse('file://directory/file1.plan');
             const epsilon = 0.1;
             // WHEN
-            const planInfo = PddlPlanParser.parseText(planText, epsilon, fileUri, 33);
+            const planInfo = new PddlPlanParser().parseText(planText, epsilon, fileUri, 33);
 
             // THEN
             expect(planInfo).to.not.be.undefined;;
@@ -122,7 +129,7 @@ describe('PddlPlanParser', () => {
             const fileUri = URI.parse('file://directory/file1.plan');
             const epsilon = 0.1;
             // WHEN
-            const planInfo = PddlPlanParser.parseText(planText, epsilon, fileUri, 33);
+            const planInfo = new PddlPlanParser().parseText(planText, epsilon, fileUri, 33);
 
             // THEN
             expect(planInfo).to.not.be.undefined;;

--- a/test/parser/PddlPlannerOutputParserTest.ts
+++ b/test/parser/PddlPlannerOutputParserTest.ts
@@ -62,7 +62,7 @@ describe('PddlPlannerOutputParser', () => {
             expect(plans).to.have.length(1, 'there should be one empty plan');
             const plan = plans[0];
             assert.strictEqual(plan.makespan, duration + startTime, 'plan makespan');
-            assert.strictEqual(plan.cost, metricNumber, 'plan cost');
+            assert.strictEqual(plan.metric, metricNumber, 'plan cost');
             expect(plan.steps).to.have.length(1, 'plan should have one action');
             assert.strictEqual(plan.steps[0].getStartTime(), startTime, 'start time');
             assert.strictEqual(plan.steps[0].getActionName(), actionName, 'action name');
@@ -89,7 +89,7 @@ describe('PddlPlannerOutputParser', () => {
             // THEN
             expect(plans).to.have.length(1, 'there should be one plan');
             const plan = plans[0];
-            assert.strictEqual(plan.cost, metricNumber, 'plan cost');
+            assert.strictEqual(plan.metric, metricNumber, 'plan cost');
             expect(plan.steps).to.have.length(1, 'plan should have one action');
         });
 
@@ -111,7 +111,7 @@ describe('PddlPlannerOutputParser', () => {
             // THEN
             expect(plans, 'there should be one empty plan').to.have.lengthOf(1);
             const plan = plans[0];
-            expect(plan.cost, 'plan cost').to.equal(metricNumber);
+            expect(plan.metric, 'plan cost').to.equal(metricNumber);
             expect(plan.steps, 'plan should have one action').to.have.lengthOf(1);
         });
 
@@ -248,21 +248,21 @@ describe('PddlPlannerOutputParser', () => {
             expect(plans, 'plans').to.have.lengthOf(9);
             {
                 const plan0 = plans[0];
-                expect(plan0.cost, 'plan0 cost').to.equal(515);
+                expect(plan0.metric, 'plan0 cost').to.equal(515);
                 expect(plan0.statesEvaluated, 'plan0 states evaluated').to.equal(10);
                 expect(plan0.makespan, 'plan0 makespan').to.equal(260.002);
                 expect(plan0.steps, 'plan0 should have one action').to.have.lengthOf(9);
             }
             {
                 const plan1 = plans[1];
-                expect(plan1.cost, 'plan1 cost').to.equal(490);
+                expect(plan1.metric, 'plan1 cost').to.equal(490);
                 expect(plan1.statesEvaluated, 'plan1 states evaluated').to.equal(413);
                 expect(plan1.makespan, 'plan1 makespan').to.equal(2150.002);
                 expect(plan1.steps, 'plan1 should have one action').to.have.lengthOf(9);
             }
             {
                 const plan8 = plans[8];
-                expect(plan8.cost, 'plan8 cost').to.equal(50);
+                expect(plan8.metric, 'plan8 cost').to.equal(50);
                 expect(plan8.statesEvaluated, 'plan8 states evaluated').to.equal(40250);
                 expect(plan8.makespan, 'plan8 makespan').to.equal(2150.002);
                 expect(plan8.steps, 'plan8 should have one action').to.have.lengthOf(8);
@@ -388,21 +388,21 @@ describe('PddlPlannerOutputParser', () => {
             expect(plans, 'plans').to.have.lengthOf(3);
             {
                 const plan0 = plans[0];
-                expect(plan0.cost, 'plan0 cost').to.equal(264.006);
+                expect(plan0.metric, 'plan0 cost').to.equal(264.006);
                 expect(plan0.statesEvaluated, 'plan0 states evaluated').to.equal(187);
                 expect(plan0.makespan, 'plan0 makespan').to.equal(264.006);
                 expect(plan0.steps, 'plan0 should have one action').to.have.lengthOf(18);
             }
             {
                 const plan1 = plans[1];
-                expect(plan1.cost, 'plan1 cost').to.equal(258.017);
+                expect(plan1.metric, 'plan1 cost').to.equal(258.017);
                 expect(plan1.statesEvaluated, 'plan1 states evaluated').to.equal(1193);
                 expect(plan1.makespan, 'plan1 makespan').to.equal(258.017);
                 expect(plan1.steps, 'plan1 should have one action').to.have.lengthOf(19);
             }
             {
                 const plan2 = plans[2];
-                expect(plan2.cost, 'plan2 cost').to.equal(227.008);
+                expect(plan2.metric, 'plan2 cost').to.equal(227.008);
                 expect(plan2.statesEvaluated, 'plan2 states evaluated').to.equal(2983);
                 expect(plan2.makespan, 'plan2 makespan').to.equal(227.008);
                 expect(plan2.steps, 'plan2 should have one action').to.have.lengthOf(19);
@@ -475,7 +475,7 @@ describe('PddlPlannerOutputParser', () => {
             expect(plans, 'plans').to.have.lengthOf(1);
             {
                 const plan0 = plans[0];
-                expect(plan0.cost, 'plan0 cost').to.equal(11);
+                expect(plan0.metric, 'plan0 cost').to.equal(11);
                 // expect(plan0.statesEvaluated, 'plan0 states evaluated').to.equal(10);
                 expect(plan0.makespan, 'plan0 makespan').to.equal(5);
                 expect(plan0.steps, 'plan0 should have N actions').to.have.lengthOf(11);
@@ -501,7 +501,7 @@ describe('PddlPlannerOutputParser', () => {
             expect(plans, 'there should be one plan').to.have.lengthOf(1);
             const plan = plans[0];
             expect(plan.makespan, 'plan makespan').to.equal(duration + startTime);
-            expect(plan.cost, 'plan cost').to.be.closeTo(metricNumber, 1e-40);
+            expect(plan.metric, 'plan cost').to.be.closeTo(metricNumber, 1e-40);
             expect(plan.steps).to.have.length(1, 'plan should have one action');
             assert.strictEqual(plan.steps[0].getStartTime(), startTime, 'start time');
             assert.strictEqual(plan.steps[0].getActionName(), actionName, 'action name');
@@ -543,7 +543,7 @@ describe('PddlPlannerOutputParser', () => {
             expect(plans).to.have.length(1, 'there should be one empty plan');
             const plan = plans[0];
             assert.strictEqual(plan.makespan, 0, 'plan makespan');
-            assert.strictEqual(plan.cost, 0, 'plan metric');
+            assert.strictEqual(plan.metric, 0, 'plan metric');
             assert.strictEqual(plan.statesEvaluated, 10, 'states evaluated');
         });
 
@@ -592,7 +592,7 @@ describe('PddlPlannerOutputParser', () => {
             expect(plans).to.have.length(1, 'there should be one plan');
             const plan = plans[0];
             assert.strictEqual(plan.makespan, 10807.2, 'plan makespan');
-            assert.strictEqual(plan.cost, 10807.2, 'plan metric');
+            assert.strictEqual(plan.metric, 10807.2, 'plan metric');
             assert.strictEqual(plan.statesEvaluated, 51, 'states evaluated');
             expect(plan.steps).to.have.length(1, 'plan should have one action');
             assert.strictEqual(plan.steps[0].getStartTime(), 10807.2, 'start time');
@@ -662,7 +662,7 @@ describe('PddlPlannerOutputParser', () => {
             expect(plans).to.have.length(1, 'there should be one plan');
             const plan = plans[0];
             assert.strictEqual(plan.makespan, 60+60*60, 'plan makespan');
-            assert.strictEqual(plan.cost, 60+60*60, 'plan metric');
+            assert.strictEqual(plan.metric, 60+60*60, 'plan metric');
             assert.strictEqual(plan.statesEvaluated, 51, 'states evaluated');
             expect(plan.steps).to.have.length(1, 'plan should have one action');
             assert.strictEqual(plan.steps[0].getStartTime(), 60, 'start time');


### PR DESCRIPTION
- re-hydrating domain/problem/plan from JSON
- file parsing deferred to support in-browser usage
- `PddlPlanParser `is no longer static class (breaking)
- `PlanInfo` may carry `metric` and `statesEvaluated`
- Plan deprecated `cost` and replaced by `metric`
- refactored plan parsing to properly centralize it in `PddlPlanParser`
- added `NormalizingPddlPlanParserTest`
- v6.0.0
- ubuntu-20.04 build image