### PR TITLE
V10.0.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,6 @@
 .vscode/
 .eslintrc.*
+.vite.config.ts
 tsconfig.json
 src/
 test/

--- a/README.md
+++ b/README.md
@@ -208,4 +208,4 @@ Starting from version 3.5.0, the `PlannerProvider` may optionally also implement
 
 ## Compiling and contributing
 
-Install node.js 12.14.1.
+Install node.js 18.16.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "test": "npx vitest",
+    "test": "npx vitest --run",
     "pretest": "npx eslint ./src/**/*.ts && npm run compile",
     "build": "tsc",
     "compile": "tsc && npm run copyToDist",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "url": "https://github.com/jan-dolejsi/pddl-workspace"
   },
   "devDependencies": {
-    "@types/node": "^16.11.7",
+    "@types/node": "^18.16.3",
     "@types/nunjucks": "^3.2.2",
     "@typescript-eslint/eslint-plugin": "^5.26.0",
     "@typescript-eslint/parser": "^5.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pddl-workspace",
-  "version": "9.0.3",
+  "version": "10.0.0",
   "description": "PDDL Workspace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/planner/PlannerProvider.ts
+++ b/src/planner/PlannerProvider.ts
@@ -31,7 +31,7 @@ export interface PlannerProvider {
     showHelp?(output: OutputAdaptor): void;
 
     /** Custom `Planner` implementation. */
-    createPlanner?(configuration: PlannerConfiguration, plannerInvocationOptions: PlannerRunConfiguration): Planner | undefined;
+    createPlanner?(configuration: PlannerConfiguration, plannerInvocationOptions: PlannerRunConfiguration): Promise<Planner | undefined> | Planner | undefined;
 
     /** Command-line (or other) options specific to this `Planner` */
     getPlannerOptions?(): PlannerOption[];

--- a/src/planner/PlannerRegistrar.ts
+++ b/src/planner/PlannerRegistrar.ts
@@ -48,6 +48,7 @@ export class WellKnownPlannerKind {
     public static readonly EXECUTABLE = new PlannerKind("EXECUTABLE");
     public static readonly JAVA_JAR = new PlannerKind("JAVA_JAR");
     public static readonly NODE_JS_SCRIPT = new PlannerKind("NODE_JS_SCRIPT");
+    public static readonly PYTHON_SCRIPT = new PlannerKind("PYTHON_SCRIPT");
     public static readonly COMMAND = new PlannerKind("COMMAND");
     public static readonly SERVICE_SYNC = new PlannerKind("SERVICE_SYNC");
     public static readonly SERVICE_ASYNC = new PlannerKind("SERVICE_ASYNC");


### PR DESCRIPTION
- optionally `async createPlanner`
- _python_ planner kind
- vitest --run (not watch)
- node 18.16
